### PR TITLE
Update find-up, add tests for undefined result

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const findUp = require('find-up');
 
 const pkgDir = async cwd => {
 	const filePath = await findUp('package.json', {cwd});
-	return filePath ? path.dirname(filePath) : undefined;
+	return filePath && path.dirname(filePath);
 };
 
 module.exports = pkgDir;
@@ -13,5 +13,5 @@ module.exports.default = pkgDir;
 
 module.exports.sync = cwd => {
 	const filePath = findUp.sync('package.json', {cwd});
-	return filePath ? path.dirname(filePath) : undefined;
+	return filePath && path.dirname(filePath);
 };

--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
 		"path"
 	],
 	"dependencies": {
-		"find-up": "^3.0.0"
+		"find-up": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
+		"tempy": "^0.3.0",
 		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}

--- a/test.js
+++ b/test.js
@@ -1,11 +1,24 @@
+import fs from 'fs';
 import path from 'path';
 import test from 'ava';
+import tempy from 'tempy';
 import pkgDir from '.';
+
+// Create a disjoint directory, used for the not-found tests
+test.beforeEach(t => {
+	t.context.disjoint = tempy.directory();
+});
+
+test.afterEach(t => {
+	fs.rmdirSync(t.context.disjoint);
+});
 
 test('async', async t => {
 	t.is(await pkgDir(path.join(__dirname, 'fixture')), __dirname);
+	t.is(await pkgDir(t.context.disjoint), undefined);
 });
 
 test('sync', t => {
 	t.is(pkgDir.sync(path.join(__dirname, 'fixture')), __dirname);
+	t.is(pkgDir.sync(t.context.disjoint), undefined);
 });


### PR DESCRIPTION
Sorry if the change to `index.js` is unwanted, I assumed the `?:` was only used to deal with `null` return from previous version of find-up.